### PR TITLE
Add type definitions for @stacks/connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@blockstack/eslint-config": "^1.0.5",
     "@blockstack/prettier-config": "^0.0.6",
+    "@stacks/stacks-blockchain-api-types": "^0.66.1",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.4.2",
     "eslint": "^7.0.0",
     "eslint-plugin-jest": "^23.16.0",


### PR DESCRIPTION
Add types for @stacks/connect "@stacks/stacks-blockchain-api-types": "^0.66.1"

Fixes the error Cannot find type definition file for '@stacks/connect' when building.